### PR TITLE
Revert HtmlCleaner to previous, functional version

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -9,7 +9,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20220920.1</version>
+      <version>1.20220927.1</version>
    </parent>
 
    <dependencies>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -9,7 +9,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20220927.1</version>
+      <version>1.20221024.1</version>
    </parent>
 
    <dependencies>

--- a/crawler/pom.xml
+++ b/crawler/pom.xml
@@ -10,7 +10,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20220920.1</version>
+      <version>1.20220927.1</version>
    </parent>
 
    <build>

--- a/crawler/pom.xml
+++ b/crawler/pom.xml
@@ -10,7 +10,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20220927.1</version>
+      <version>1.20221024.1</version>
    </parent>
 
    <build>

--- a/dumpass/pom.xml
+++ b/dumpass/pom.xml
@@ -9,7 +9,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20220920.1</version>
+      <version>1.20220927.1</version>
    </parent>
 
    <build>

--- a/dumpass/pom.xml
+++ b/dumpass/pom.xml
@@ -9,7 +9,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20220927.1</version>
+      <version>1.20221024.1</version>
    </parent>
 
    <build>

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -10,7 +10,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20220920.1</version>
+      <version>1.20220927.1</version>
    </parent>
 
    <build>

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -10,7 +10,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20220927.1</version>
+      <version>1.20221024.1</version>
    </parent>
 
    <build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
    <groupId>mkr</groupId>
    <artifactId>util-pom</artifactId>
    <name>mkr util pom</name>
-   <version>1.20220920.1</version><!--util.version-->
+   <version>1.20220927.1</version><!--util.version-->
    <packaging>pom</packaging>
 
    <modules>
@@ -23,7 +23,7 @@
 
    <properties>
       <spring.version>3.2.13.RELEASE</spring.version>
-      <dump.version>1.20220919.1</dump.version>
+      <dump.version>1.20220927.1</dump.version>
    </properties>
 
    <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
    <groupId>mkr</groupId>
    <artifactId>util-pom</artifactId>
    <name>mkr util pom</name>
-   <version>1.20220927.1</version><!--util.version-->
+   <version>1.20221024.1</version><!--util.version-->
    <packaging>pom</packaging>
 
    <modules>
@@ -23,7 +23,7 @@
 
    <properties>
       <spring.version>3.2.13.RELEASE</spring.version>
-      <dump.version>1.20220927.1</dump.version>
+      <dump.version>1.20221024.1</dump.version>
    </properties>
 
    <scm>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -10,7 +10,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20220920.1</version>
+      <version>1.20220927.1</version>
    </parent>
 
    <build>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -10,7 +10,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20220927.1</version>
+      <version>1.20221024.1</version>
    </parent>
 
    <build>

--- a/ssh/pom.xml
+++ b/ssh/pom.xml
@@ -10,7 +10,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20220920.1</version>
+      <version>1.20220927.1</version>
    </parent>
 
    <build>

--- a/ssh/pom.xml
+++ b/ssh/pom.xml
@@ -10,7 +10,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20220927.1</version>
+      <version>1.20221024.1</version>
    </parent>
 
    <build>

--- a/svm/pom.xml
+++ b/svm/pom.xml
@@ -9,7 +9,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20220920.1</version>
+      <version>1.20220927.1</version>
    </parent>
 
    <build>

--- a/svm/pom.xml
+++ b/svm/pom.xml
@@ -9,7 +9,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20220927.1</version>
+      <version>1.20221024.1</version>
    </parent>
 
    <build>

--- a/swt/pom.xml
+++ b/swt/pom.xml
@@ -9,7 +9,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20220920.1</version>
+      <version>1.20220927.1</version>
    </parent>
 
    <profiles>

--- a/swt/pom.xml
+++ b/swt/pom.xml
@@ -9,7 +9,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20220927.1</version>
+      <version>1.20221024.1</version>
    </parent>
 
    <profiles>

--- a/usagetracking/pom.xml
+++ b/usagetracking/pom.xml
@@ -10,7 +10,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20220927.1</version>
+      <version>1.20221024.1</version>
    </parent>
 
    <dependencies>

--- a/usagetracking/pom.xml
+++ b/usagetracking/pom.xml
@@ -10,7 +10,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20220920.1</version>
+      <version>1.20220927.1</version>
    </parent>
 
    <dependencies>

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -9,7 +9,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20220920.1</version>
+      <version>1.20220927.1</version>
    </parent>
 
    <dependencies>

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -9,7 +9,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20220927.1</version>
+      <version>1.20221024.1</version>
    </parent>
 
    <dependencies>

--- a/xslt/pom.xml
+++ b/xslt/pom.xml
@@ -26,9 +26,9 @@
       </dependency>
 
       <dependency>
-         <groupId>net.sourceforge.htmlcleaner</groupId>
+         <groupId>org.htmlcleaner</groupId>
          <artifactId>htmlcleaner</artifactId>
-         <version>2.26</version>
+         <version>2.1</version>
       </dependency>
 
       <dependency>

--- a/xslt/pom.xml
+++ b/xslt/pom.xml
@@ -10,7 +10,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20220927.1</version>
+      <version>1.20221024.1</version>
    </parent>
 
    <dependencies>

--- a/xslt/pom.xml
+++ b/xslt/pom.xml
@@ -10,7 +10,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20220920.1</version>
+      <version>1.20220927.1</version>
    </parent>
 
    <dependencies>

--- a/xslt/src/util/xslt/LenientDomSerializer.java
+++ b/xslt/src/util/xslt/LenientDomSerializer.java
@@ -8,8 +8,8 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.htmlcleaner.CleanerProperties;
-import org.htmlcleaner.CommentNode;
-import org.htmlcleaner.ContentNode;
+import org.htmlcleaner.CommentToken;
+import org.htmlcleaner.ContentToken;
 import org.htmlcleaner.TagNode;
 import org.htmlcleaner.Utils;
 import org.w3c.dom.Document;
@@ -23,7 +23,8 @@ import org.w3c.dom.Node;
 public class LenientDomSerializer {
 
    protected CleanerProperties props;
-   protected boolean           escapeXml;
+   protected boolean           escapeXml = true;
+
 
    public LenientDomSerializer( CleanerProperties paramCleanerProperties, boolean paramBoolean ) {
       props = paramCleanerProperties;
@@ -54,23 +55,23 @@ public class LenientDomSerializer {
             Object localObject1 = localIterator1.next();
             Object localObject2;
             Object localObject3;
-            if ( (localObject1 instanceof CommentNode) ) {
+            if ( (localObject1 instanceof CommentToken) ) {
                localObject2 = localObject1;
-               localObject3 = paramDocument.createComment(((CommentNode)localObject2).getContent());
+               localObject3 = paramDocument.createComment(((CommentToken)localObject2).getContent());
                paramElement.appendChild((Node)localObject3);
             } else {
                Object localObject4;
-               if ( (localObject1 instanceof ContentNode) ) {
+               if ( (localObject1 instanceof ContentToken) ) {
                   localObject2 = paramElement.getNodeName();
                   localObject3 = localObject1;
-                  localObject4 = ((ContentNode)localObject3).getContent();
-                  int i = (props.isUseCdataForScriptAndStyle()) && (("script".equalsIgnoreCase((String)localObject2)) || ("style".equalsIgnoreCase(
-                        (String)localObject2))) ? 1 : 0;
+                  localObject4 = ((ContentToken)localObject3).getContent();
+                  int i = (props.isUseCdataForScriptAndStyle())
+                     && (("script".equalsIgnoreCase((String)localObject2)) || ("style".equalsIgnoreCase((String)localObject2))) ? 1 : 0;
                   if ( (escapeXml) && (i == 0) ) {
                      localObject4 = Utils.escapeXml((String)localObject4, props, true);
                   }
-                  paramElement.appendChild(
-                        i != 0 ? paramDocument.createCDATASection((String)localObject4) : paramDocument.createTextNode((String)localObject4));
+                  paramElement
+                        .appendChild(i != 0 ? paramDocument.createCDATASection((String)localObject4) : paramDocument.createTextNode((String)localObject4));
                } else if ( (localObject1 instanceof TagNode) ) {
                   localObject2 = localObject1;
                   localObject3 = paramDocument.createElement(((TagNode)localObject2).getName());


### PR DESCRIPTION
Since we cannot simply go forward with the bumped HtmlCleaner version, go back.