### PR TITLE
bump dependency on dump, and version

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -9,7 +9,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20230207.1</version>
+      <version>1.20230306.1</version>
    </parent>
 
    <dependencies>

--- a/crawler/pom.xml
+++ b/crawler/pom.xml
@@ -10,7 +10,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20230207.1</version>
+      <version>1.20230306.1</version>
    </parent>
 
    <build>

--- a/dumpass/pom.xml
+++ b/dumpass/pom.xml
@@ -9,7 +9,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20230207.1</version>
+      <version>1.20230306.1</version>
    </parent>
 
    <build>

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -10,7 +10,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20230207.1</version>
+      <version>1.20230306.1</version>
    </parent>
 
    <build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
    <groupId>mkr</groupId>
    <artifactId>util-pom</artifactId>
    <name>mkr util pom</name>
-   <version>1.20230207.1</version><!--util.version-->
+   <version>1.20230306.1</version><!--util.version-->
    <packaging>pom</packaging>
 
    <modules>
@@ -23,7 +23,7 @@
 
    <properties>
       <spring.version>3.2.13.RELEASE</spring.version>
-      <dump.version>1.20221024.1</dump.version>
+      <dump.version>1.20230306.1</dump.version>
    </properties>
 
    <scm>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -10,7 +10,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20230207.1</version>
+      <version>1.20230306.1</version>
    </parent>
 
    <build>

--- a/ssh/pom.xml
+++ b/ssh/pom.xml
@@ -10,7 +10,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20230207.1</version>
+      <version>1.20230306.1</version>
    </parent>
 
    <build>

--- a/svm/pom.xml
+++ b/svm/pom.xml
@@ -9,7 +9,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20230207.1</version>
+      <version>1.20230306.1</version>
    </parent>
 
    <build>

--- a/swt/pom.xml
+++ b/swt/pom.xml
@@ -9,7 +9,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20230207.1</version>
+      <version>1.20230306.1</version>
    </parent>
 
    <profiles>

--- a/usagetracking/pom.xml
+++ b/usagetracking/pom.xml
@@ -10,7 +10,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20230207.1</version>
+      <version>1.20230306.1</version>
    </parent>
 
    <dependencies>

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -9,7 +9,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20230207.1</version>
+      <version>1.20230306.1</version>
    </parent>
 
    <dependencies>

--- a/xslt/pom.xml
+++ b/xslt/pom.xml
@@ -10,7 +10,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>util-pom</artifactId>
-      <version>1.20230207.1</version>
+      <version>1.20230306.1</version>
    </parent>
 
    <dependencies>


### PR DESCRIPTION
More fine-grained error handling, allows to recreate just the affected index instead of the whole dump, if the latter is still consistent.